### PR TITLE
fix: use the same OfferTxInfo with crypto package

### DIFF
--- a/types/tx_request.go
+++ b/types/tx_request.go
@@ -4,24 +4,6 @@ import (
 	"math/big"
 )
 
-type OfferTxInfo struct {
-	Type                int64
-	OfferId             int64
-	AccountIndex        int64
-	NftIndex            int64
-	AssetId             int64
-	AssetAmount         *big.Int
-	ListedAt            int64
-	ExpiredAt           int64
-	RoyaltyRate         int64
-	ChannelAccountIndex int64
-	ChannelRate         int64
-	ProtocolRate        int64
-	ProtocolAmount      *big.Int
-	Sig                 []byte
-	L1Sig               string
-}
-
 type ChangePubKeyReq struct {
 	L1Address string
 	PubKeyX   [32]byte

--- a/types/tx_type.go
+++ b/types/tx_type.go
@@ -16,6 +16,7 @@ type (
 	TransferTxInfo         = txtypes.TransferTxInfo
 	WithdrawNftTxInfo      = txtypes.WithdrawNftTxInfo
 	WithdrawTxInfo         = txtypes.WithdrawTxInfo
+	OfferTxInfo            = txtypes.OfferTxInfo
 )
 
 const (


### PR DESCRIPTION
### Description

Use the same OfferTxInfo with crypto package

### Rationale

So that we can use the function in crypto OfferTxInfo, such as GetL1AddressBySignature

### Example

N/A

### Changes

Notable changes:
* Update the OfferTxInfo definition in this package