### PR TITLE
fix: correct the PubKey fields in ChangePubKeyTxInfo

### DIFF
--- a/types/tx_type.go
+++ b/types/tx_type.go
@@ -136,7 +136,8 @@ type ChangePubKeyTxInfo struct {
 	TxType       uint8
 	AccountIndex int64
 	L1Address    string
-	PubKey       string
+	PubKeyX      string
+	PubKeyY      string
 }
 
 func ParseChangePubKeyTxInfo(txInfoStr string) (txInfo *ChangePubKeyTxInfo, err error) {


### PR DESCRIPTION
### Description

Use PubKeyX and PubKeyY instead of PubKey

### Rationale

PubKey field not exists in txInfo, there are only PubKeyX and PubKeyY fields 

### Example

N/A

### Changes

N/A