### PR TITLE
fix: use []byte instead of string for parsing

### DIFF
--- a/types/tx_type.go
+++ b/types/tx_type.go
@@ -136,8 +136,8 @@ type ChangePubKeyTxInfo struct {
 	TxType       uint8
 	AccountIndex int64
 	L1Address    string
-	PubKeyX      string
-	PubKeyY      string
+	PubKeyX      []byte
+	PubKeyY      []byte
 }
 
 func ParseChangePubKeyTxInfo(txInfoStr string) (txInfo *ChangePubKeyTxInfo, err error) {


### PR DESCRIPTION
### Description

use []byte instead of string for parsing

### Rationale

Follow the same type with zkbnb so that we can use the same logic to construct the pubKey

### Example

N/A

### Changes

N/A